### PR TITLE
Removing deprecated Navigator component.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-exponent "0.1.6"
+(defproject cljs-exponent "0.1.7"
   :description "Expo cljs binding"
   :url "https://github.com/tiensonqin/cljs-exponent"
   :license {:name "Eclipse Public License"

--- a/src/cljs_exponent/components.cljc
+++ b/src/cljs_exponent/components.cljc
@@ -57,7 +57,6 @@
    "Image"
    "ListView"
    "Modal"
-   "Navigator"
    "NavigatorIOS"
    "Picker"
    "PickerIOS"


### PR DESCRIPTION
Navigator is now deprecated and Expo 18 will result in error with this dep. Simply removing it fixes this.

https://github.com/facebook/react-native/issues/12103

Related, https://github.com/seantempesta/cljs-react-navigation is a fine start to react-navigation wrapper for use in our reframe apps.